### PR TITLE
Additional filtering for Timing Evolution plots

### DIFF
--- a/timering/app.py
+++ b/timering/app.py
@@ -40,6 +40,13 @@ with st.sidebar:
             nicerintmode = st.selectbox("NICER",
                                         options=["all", "full", "gti"]
                                         )
+        st.markdown(r"Error (m$hz$):")
+        set3, set4 = st.columns(2)
+        with set3:
+            minerr = st.text_input("Min", value=0.0)
+        with set4:
+            maxerr = st.text_input("Max", value=1.0)
+
 
 st.session_state.show_df = show_df
 
@@ -60,11 +67,23 @@ def filter_intmode(table, intmode):
     return table
 
 
+def filtermax(table, column, maxbound):
+    table = table.loc[table[column] <= float(maxbound)]
+    return table
+
+
+def filtermin(table, column, minbound):
+    table = table.loc[table[column] >= float(minbound)]
+    return table
+
+
 nitable = querymission("NICER")
 nitable = filter_intmode(nitable, nicerintmode)
 xtetable = querymission("XTE")
 xtetable = filter_intmode(xtetable, xteintmode)
 table_in = pd.merge(xtetable, nitable, how="outer")
+table_in = filtermax(table_in, "NU_ERR", maxerr)
+table_in = filtermin(table_in, "NU_ERR", minerr)
 
 
 def tevo_plot(plottype):
@@ -88,7 +107,7 @@ def tevo_plot(plottype):
             error_y="NU_ERR",
             markers=True,
         )
-    fig.update_layout(xaxis_title="Time", yaxis_title=r"Spin Frequency $\nu$")
+    fig.update_layout(xaxis_title="Time", yaxis_title=r"Spin Frequency (hz)")
     fig.update_xaxes(showgrid=True)
     fig.update_yaxes(showgrid=True)
     return fig

--- a/timering/app.py
+++ b/timering/app.py
@@ -40,7 +40,7 @@ with st.sidebar:
             nicerintmode = st.selectbox("NICER",
                                         options=["all", "full", "gti"]
                                         )
-        st.markdown(r"Error (m$hz$):")
+        st.markdown(r"Error ($hz$):")
         set3, set4 = st.columns(2)
         with set3:
             minerr = st.text_input("Min", value=0.0)
@@ -86,11 +86,11 @@ table_in = filtermax(table_in, "NU_ERR", maxerr)
 table_in = filtermin(table_in, "NU_ERR", minerr)
 
 
-def tevo_plot(plottype):
+def tevo_plot(table, plottype):
     fig = 0
     if plottype == "Scatter":
         fig = px.scatter(
-            table_in,
+            table,
             x="TIME",
             y="NU",
             title="Timing Evolution",
@@ -99,7 +99,7 @@ def tevo_plot(plottype):
         )
     else:
         fig = px.line(
-            table_in,
+            table,
             x="TIME",
             y="NU",
             title="Timing Evolution",
@@ -113,6 +113,11 @@ def tevo_plot(plottype):
     return fig
 
 
-st.plotly_chart(tevo_plot(plottype))
+st.plotly_chart(tevo_plot(table_in, plottype))
+
+total, tnicer, txte = st.columns(3)
+total.metric("Total", len(table_in["NU"]))
+tnicer.metric("NICER", len(table_in.loc[table_in["MISSION"] == "NICER"]))
+txte.metric("XTE", len(table_in.loc[table_in["MISSION"] == "XTE"]))
 if st.session_state.show_df == "On":
     crab_table = st.dataframe(table_in)

--- a/timering/app.py
+++ b/timering/app.py
@@ -81,6 +81,8 @@ with st.sidebar:
             maxerr = st.text_input("Max Error", value=1.0)
         table_in = filtermax(table_in, "NU_ERR", maxerr)
         table_in = filtermin(table_in, "NU_ERR", minerr)
+        minzn2 = st.text_input("Min $Z_n^2$", value=30.0)
+        table_in = filtermin(table_in, "ZN2", minzn2)
         st.markdown(r"$\nu$ Gaussian Fit Error (hz)")
         set5, set6 = st.columns(2)
         with set5:

--- a/timering/app.py
+++ b/timering/app.py
@@ -89,15 +89,22 @@ with st.sidebar:
             maxgerr = st.text_input("Max Gaussian Error", value=1.0)
         table_in = filtermax(table_in, "G_NU_ERR", maxgerr)
         table_in = filtermin(table_in, "G_NU_ERR", mingerr)
-
         st.markdown(r"Exposure (s)")
-        set5, set6 = st.columns(2)
-        with set5:
-            mingerr = st.text_input("Min Exposure", value=0.0)
-        with set6:
-            maxgerr = st.text_input("Max Exposure", value=1000000)
-        table_in = filtermax(table_in, "EXPOSURE", maxgerr)
-        table_in = filtermin(table_in, "EXPOSURE", mingerr)
+        set7, set8 = st.columns(2)
+        with set7:
+            minexpo = st.text_input("Min Exposure", value=0.0)
+        with set8:
+            maxexpo = st.text_input("Max Exposure", value=1000000)
+        table_in = filtermax(table_in, "EXPOSURE", maxexpo)
+        table_in = filtermin(table_in, "EXPOSURE", minexpo)
+        st.markdown(r"Arrival Times (counts)")
+        set9, set10 = st.columns(2)
+        with set9:
+            minats = st.text_input("Min ATs", value=0.0)
+        with set10:
+            maxats = st.text_input("Max ATs", value=1000000000)
+        table_in = filtermax(table_in, "ATS", maxats)
+        table_in = filtermin(table_in, "ATS", minats)
 st.session_state.show_df = show_df
 
 

--- a/timering/app.py
+++ b/timering/app.py
@@ -84,12 +84,20 @@ with st.sidebar:
         st.markdown(r"$\nu$ Gaussian Fit Error (hz)")
         set5, set6 = st.columns(2)
         with set5:
-            mingerr = st.text_input("Min Gaussian Error", value=0.0)
+            mingerr = st.text_input("Min Gaussian Error", value=-0.1)
         with set6:
             maxgerr = st.text_input("Max Gaussian Error", value=1.0)
         table_in = filtermax(table_in, "G_NU_ERR", maxgerr)
         table_in = filtermin(table_in, "G_NU_ERR", mingerr)
 
+        st.markdown(r"Exposure (s)")
+        set5, set6 = st.columns(2)
+        with set5:
+            mingerr = st.text_input("Min Exposure", value=0.0)
+        with set6:
+            maxgerr = st.text_input("Max Exposure", value=1000000)
+        table_in = filtermax(table_in, "EXPOSURE", maxgerr)
+        table_in = filtermin(table_in, "EXPOSURE", mingerr)
 st.session_state.show_df = show_df
 
 

--- a/timering/app.py
+++ b/timering/app.py
@@ -25,13 +25,21 @@ with st.sidebar:
     dbpath = st.text_input("Local database path", value=pargs.database)
     dbpath = pathlib.Path(dbpath).resolve()
     plottype = st.radio("Timing Evolution Plot Type", ["Line", "Scatter"])
-    intmode = st.selectbox("Interval mode selection:",
-                           options=["all", "full", "gti"]
-                           )
     show_df = st.radio(
         "Show Data Table",
         ["Off", "On"],
     )
+    with st.expander("Timing Evolution Filters"):
+        st.markdown("Interval Modes:")
+        set1, set2 = st.columns(2)
+        with set1:
+            xteintmode = st.selectbox("XTE",
+                                      options=["all", "full", "gti"]
+                                      )
+        with set2:
+            nicerintmode = st.selectbox("NICER",
+                                        options=["all", "full", "gti"]
+                                        )
 
 st.session_state.show_df = show_df
 
@@ -39,8 +47,24 @@ con = sqlite3.connect(dbpath)
 table_in = pd.read_sql_query("SELECT * FROM nu_results", con)
 table_in["TIME"] = pd.to_datetime(table_in["TIME"])
 table_in = table_in.sort_values(by="TIME")
-if intmode != "all":
-    table_in = table_in.loc[table_in["MODE"] == intmode]
+
+
+def querymission(mission):
+    mtable = table_in.loc[table_in["MISSION"] == mission.upper()]
+    return mtable
+
+
+def filter_intmode(table, intmode):
+    if intmode != "all":
+        table = table.loc[table["MODE"] == intmode.lower()]
+    return table
+
+
+nitable = querymission("NICER")
+nitable = filter_intmode(nitable, nicerintmode)
+xtetable = querymission("XTE")
+xtetable = filter_intmode(xtetable, xteintmode)
+table_in = pd.merge(xtetable, nitable, how="outer")
 
 
 def tevo_plot(plottype):
@@ -65,8 +89,8 @@ def tevo_plot(plottype):
             markers=True,
         )
     fig.update_layout(xaxis_title="Time", yaxis_title=r"Spin Frequency $\nu$")
-    fig.update_xaxes(showgrid=False)
-    fig.update_yaxes(showgrid=False)
+    fig.update_xaxes(showgrid=True)
+    fig.update_yaxes(showgrid=True)
     return fig
 
 


### PR DESCRIPTION
This PR is for the addition of functionality for the Timing evolution plot, and table. The point here is to add in filtering for:

- filtering specific missions by the interval mode used in measurement
- filtering out minimum and maximum error bars
- min/max filtering out based on $Z_1^2$

And potentially filtering based on Gaussian fitting to the $Z_1^2$ results (Although that might be better left to its own PR).