### PR TITLE
Fix plotline after filtering 

### DIFF
--- a/timering/app.py
+++ b/timering/app.py
@@ -245,6 +245,7 @@ def main(pargs: argparse.Namespace):
                 logger.debug(f"Max Arrival times set to {maxats}")
             table_in = filtermax(table_in, "ATS", maxats)
             table_in = filtermin(table_in, "ATS", minats)
+    table_in = table_in.sort_values(by="TIME")
     st.session_state.show_df = show_df
     st.markdown(r"## $\nu$ Evolution")
 


### PR DESCRIPTION
This PR adds in one line to reorder the results table after the filtering block to reorder by TIME. This will address #21 