### PR TITLE
Refactor Timing Evolution Min/Max Filters

### DIFF
--- a/timering/app.py
+++ b/timering/app.py
@@ -160,6 +160,7 @@ class Dashboard:
         self.active_src = self.get_src()
         self.obsids = self.get_obsids()
         self.nuresults = self.get_nuresults()
+        self.nuevo_filters = {}
 
     def catalog_options_parsing(self):
         """
@@ -218,6 +219,19 @@ class Dashboard:
                            data=csvdata,
                            file_name=f"{self.active_src}.csv",
                            mime='text/csv')
+
+    def min_max_columns(self, column: str, default: tuple):
+        seta, setb = st.columns(2)
+        with seta:
+            minval = st.text_input(f"Min {column}", value=default[0])
+            self.nuevo_filters[f"min_{column}"] = minval
+            self.logger.debug(f"Min {column} set to {minval}")
+        with setb:
+            maxval = st.text_input(f"Max {column}", value=default[1])
+            self.nuevo_filters[f"max_{column}"] = maxval
+            self.logger.debug(f"Max {column} set to {maxval}")
+        table_in = self.min_max_filters(column, minval, maxval)
+        return table_in
 
 
 def main(pargs: argparse.Namespace):
@@ -295,14 +309,7 @@ def main(pargs: argparse.Namespace):
                 logger.debug(f"Max Exposure set to {maxexpo}")
             table_in = dashboard.min_max_filters("EXPOSURE", minexpo, maxexpo)
             st.markdown(r"Arrival Times (counts)")
-            set9, set10 = st.columns(2)
-            with set9:
-                minats = st.text_input("Min ATs", value=0.0)
-                logger.debug(f"Min Arrival times set to {minats}")
-            with set10:
-                maxats = st.text_input("Max ATs", value=1000000000)
-                logger.debug(f"Max Arrival times set to {maxats}")
-            table_in = dashboard.min_max_filters("ATS", minats, maxats)
+            table_in = dashboard.min_max_columns("ATS", (0.0, 1000000000))
             nitable = querymission(table_in, "NICER")
             nitable = filter_intmode(nitable, nicerintmode)
             xtetable = querymission(table_in, "XTE")

--- a/timering/app.py
+++ b/timering/app.py
@@ -300,14 +300,7 @@ def main(pargs: argparse.Namespace):
                 logger.debug(f"Max Gaussian error set to {maxgerr}")
             table_in = dashboard.min_max_filters("G_NU_ERR", mingerr, maxgerr)
             st.markdown(r"Exposure (s)")
-            set7, set8 = st.columns(2)
-            with set7:
-                minexpo = st.text_input("Min Exposure", value=0.0)
-                logger.debug(f"Min exposure set to {minexpo}")
-            with set8:
-                maxexpo = st.text_input("Max Exposure", value=1000000)
-                logger.debug(f"Max Exposure set to {maxexpo}")
-            table_in = dashboard.min_max_filters("EXPOSURE", minexpo, maxexpo)
+            table_in = dashboard.min_max_columns("EXPOSURE", (0.0, 1000000))
             st.markdown(r"Arrival Times (counts)")
             table_in = dashboard.min_max_columns("ATS", (0.0, 1000000000))
             nitable = querymission(table_in, "NICER")

--- a/timering/app.py
+++ b/timering/app.py
@@ -280,14 +280,7 @@ def main(pargs: argparse.Namespace):
             obsouts = st.multiselect("OBSID Exclusions", dashboard.obsids)
             st.session_state.obsouts = obsouts
             st.markdown(r"$\nu$ Error (hz)")
-            set3, set4 = st.columns(2)
-            with set3:
-                minerr = st.text_input("Min Error", value=0.0)
-                logger.debug(f"Min Error set to {minerr}")
-            with set4:
-                maxerr = st.text_input("Max Error", value=1.0)
-                logger.debug(f"Max Eror set to {maxerr}")
-            table_in = dashboard.min_max_filters("NU_ERR", minerr, maxerr)
+            table_in = dashboard.min_max_columns("NU_ERR", (0.0, 1.0))
             minzn2 = st.text_input("Min $Z_n^2$", value=30.0)
             table_in = filtermin(table_in, "ZN2", minzn2)
             st.markdown(r"$\nu$ Gaussian Fit Error (hz)")

--- a/timering/app.py
+++ b/timering/app.py
@@ -291,14 +291,7 @@ def main(pargs: argparse.Namespace):
             minzn2 = st.text_input("Min $Z_n^2$", value=30.0)
             table_in = filtermin(table_in, "ZN2", minzn2)
             st.markdown(r"$\nu$ Gaussian Fit Error (hz)")
-            set5, set6 = st.columns(2)
-            with set5:
-                mingerr = st.text_input("Min Gaussian Error", value=-0.1)
-                logger.debug(f"Min Gaussian Fit error set to {mingerr}")
-            with set6:
-                maxgerr = st.text_input("Max Gaussian Error", value=1.0)
-                logger.debug(f"Max Gaussian error set to {maxgerr}")
-            table_in = dashboard.min_max_filters("G_NU_ERR", mingerr, maxgerr)
+            table_in = dashboard.min_max_columns("G_NU_ERR", (-0.1, 1.0))
             st.markdown(r"Exposure (s)")
             table_in = dashboard.min_max_columns("EXPOSURE", (0.0, 1000000))
             st.markdown(r"Arrival Times (counts)")

--- a/timering/app.py
+++ b/timering/app.py
@@ -212,6 +212,13 @@ class Dashboard:
         self.nuresults = filtermin(self.nuresults, column, minval)
         return self.nuresults
 
+    def downloadcsv(self, data, label: str) -> None:
+        csvdata = makecsv(data)
+        st.download_button(label=label,
+                           data=csvdata,
+                           file_name=f"{self.active_src}.csv",
+                           mime='text/csv')
+
 
 def main(pargs: argparse.Namespace):
     level = logging.WARNING
@@ -316,17 +323,9 @@ def main(pargs: argparse.Namespace):
 
     dall, dfilt = st.columns(2)
     with dall:
-        unfilteredcsv = makecsv(unfiltereddf)
-        st.download_button(label="Download Unfiltered Data",
-                           data=unfilteredcsv,
-                           file_name=f"{dashboard.active_src}-all.csv",
-                           mime='text/csv')
+        dashboard.downloadcsv(unfiltereddf, "Download Unfiltered Data")
     with dfilt:
-        unfilteredcsv = makecsv(table_in)
-        st.download_button(label="Download Filtered Data",
-                           data=unfilteredcsv,
-                           file_name=f"{dashboard.active_src}-filtered.csv",
-                           mime='text/csv')
+        dashboard.downloadcsv(table_in, "Download Filtered Data")
     if st.session_state.show_df is True:
         st.dataframe(table_in, use_container_width=True)
         st.markdown(messages.tableinfo())


### PR DESCRIPTION
With this PR the filters in the timing evolution drop down menu in the sidebar got refactored to become apart of the Dashboard class.

Any of the parameters that had min/max filters had the newly created Dashboard.min_max_columns() function applied to them.

This included the following columns:

-  ATS
- EXPOSURE
- G_NU_ERR
- NU_ERR

Lastly, Dashboard.downloadcsv() was created to clean up the downloading of filtered and unfiltered csv's.