### PR TITLE
Export filter settings for nu evolution via a json file

### DIFF
--- a/timering/app.py
+++ b/timering/app.py
@@ -170,7 +170,7 @@ class Dashboard:
         self.logger = logger
         self.sources = []
         self.srcsel = ""
-        self.dbpath = self.catalog_options_parsing()
+        self.dbpath, self.settings = self.catalog_options_parsing()
         self.con = self.connect_twdb()
         self.active_src = self.get_src()
         self.obsids = self.get_obsids()
@@ -189,12 +189,16 @@ class Dashboard:
                 dbpath_in = st.text_input("Local database path",
                                           value=pargs.database)
                 dbpath = pathlib.Path(dbpath_in).resolve()
+                settings = st.text_input("Filter settings", value=None)
+                settings = pathlib.Path(settings).resolve()
             else:
                 self.sources = parse_config(pargs.config)
                 self.srcsel = st.selectbox("Source", self.sources)
                 dbpath = pathlib.Path(self.sources[self.srcsel]
                                                   ["database"]).resolve()
-            return dbpath
+                settings = pathlib.Path(self.sources[self.srcsel]
+                                                    ["settings"]).resolve()
+            return dbpath, settings
 
     def connect_twdb(self):
         try:

--- a/timering/app.py
+++ b/timering/app.py
@@ -68,11 +68,6 @@ def filtermax(table, column, maxbound):
     return table
 
 
-def filtermin(table, column, minbound):
-    table = table.loc[table[column] >= float(minbound)]
-    return table
-
-
 def filter_obsidout(table, obsid):
     """
     Filters out the input table of a specific OBSID
@@ -248,10 +243,16 @@ class Dashboard:
         table_in.drop(columns="EVTID", axis=1, inplace=True)
         return table_in
 
+    def filtermin(self, table, column, minbound):
+        table = table.loc[table[column] >= float(minbound)]
+        self.nuevo_filters[f"min_{column}"] = minbound
+        self.logger.debug(f"Min {column} set to {minbound}")
+        return table
+
     def min_max_filters(self, column: str, minval: float,
                         maxval: float):
         self.nuresults = filtermax(self.nuresults, column, maxval)
-        self.nuresults = filtermin(self.nuresults, column, minval)
+        self.nuresults = self.filtermin(self.nuresults, column, minval)
         return self.nuresults
 
     def downloadcsv(self, data, label: str) -> None:
@@ -272,8 +273,6 @@ class Dashboard:
         seta, setb = st.columns(2)
         with seta:
             minval = st.text_input(f"Min {column}", value=default[0])
-            self.nuevo_filters[f"min_{column}"] = minval
-            self.logger.debug(f"Min {column} set to {minval}")
         with setb:
             maxval = st.text_input(f"Max {column}", value=default[1])
             self.nuevo_filters[f"max_{column}"] = maxval
@@ -365,7 +364,7 @@ def main(pargs: argparse.Namespace):
             ats_bounds = (filters["min_ATS"], filters["max_ATS"])
             st.markdown(r"Arrival Times (counts)")
             table_in = dashboard.min_max_columns("ATS", ats_bounds)
-            table_in = filtermin(table_in, "ZN2", minzn2)
+            table_in = dashboard.filtermin(table_in, "ZN2", minzn2)
             nitable = querymission(table_in, "NICER")
             nitable = filter_intmode(nitable, nicerintmode)
             xtetable = querymission(table_in, "XTE")

--- a/timering/app.py
+++ b/timering/app.py
@@ -256,6 +256,14 @@ class Dashboard:
         table_in = self.min_max_filters(column, minval, maxval)
         return table_in
 
+    def interval_mode_filter(self, column: str):
+        intmode = st.selectbox(column,
+                               options=["all", "full", "gti"]
+                               )
+        self.logger.debug(f"{column} Interval Mode set to {intmode}")
+        self.nuevo_filters[f"{column}_interval_mode"] = intmode
+        return intmode
+
 
 def main(pargs: argparse.Namespace):
     level = logging.WARNING
@@ -295,15 +303,9 @@ def main(pargs: argparse.Namespace):
             st.markdown("Interval Modes:")
             set1, set2 = st.columns(2)
             with set1:
-                xteintmode = st.selectbox("XTE",
-                                          options=["all", "full", "gti"]
-                                          )
-                logger.debug(f"XTE Interval Mode set to {xteintmode}")
+                xteintmode = dashboard.interval_mode_filter("XTE")
             with set2:
-                nicerintmode = st.selectbox("NICER",
-                                            options=["all", "full", "gti"]
-                                            )
-                logger.debug(f"NICER Interval Mode set to {nicerintmode}")
+                nicerintmode = dashboard.interval_mode_filter("NICER")
             obsouts = st.multiselect("OBSID Exclusions", dashboard.obsids)
             st.session_state.obsouts = obsouts
             ridouts = st.multiselect("ResultID (RID) Exclusions",

--- a/timering/app.py
+++ b/timering/app.py
@@ -409,8 +409,10 @@ def main(pargs: argparse.Namespace):
             st.markdown(messages.crabtime_credit())
 
     try:
-        mif = pd.read_sql("SELECT missions.OBSID, missions.TWR_FILE FROM missions " +
-                          "WHERE missions.TWR_FILE IS NOT NULL", dashboard.con)
+        mif = pd.read_sql(("SELECT missions.OBSID, missions.TWR_FILE "
+                           "FROM missions "
+                           "WHERE missions.TWR_FILE IS NOT NULL"),
+                          dashboard.con)
     except pd.errors.DatabaseError:
         logger.warning("No missions Table Found")
         mif = pd.DataFrame({"OBSID": []})

--- a/timering/app.py
+++ b/timering/app.py
@@ -157,6 +157,13 @@ def makecsv(df):
     return df.to_csv().encode('utf-8')
 
 
+def settingsdump(settingdict: dict):
+    """
+    Dumps settings dict into a json file
+    """
+    return json.dumps(settingdict, indent=4)
+
+
 class Dashboard:
 
     def __init__(self, pargs, logger):
@@ -228,6 +235,13 @@ class Dashboard:
                            data=csvdata,
                            file_name=f"{self.active_src}.csv",
                            mime='text/csv')
+
+    def downloadsettings(self) -> None:
+        jsonsettings = settingsdump(self.nuevo_filters)
+        st.download_button(label="Download Settings",
+                           data=jsonsettings,
+                           file_name=f"{self.srcsel}-settings.json",
+                           mime="application/json")
 
     def min_max_columns(self, column: str, default: tuple):
         seta, setb = st.columns(2)
@@ -314,6 +328,7 @@ def main(pargs: argparse.Namespace):
                 table_in = filter_obsidout(table_in, i)
             for i in ridouts:
                 table_in = filter_ridout(table_in, i)
+            dashboard.downloadsettings()
     table_in = table_in.sort_values(by="TIME")
     st.session_state.show_df = show_df
     st.markdown(r"## $\nu$ Evolution")

--- a/timering/app.py
+++ b/timering/app.py
@@ -264,6 +264,11 @@ class Dashboard:
         self.nuevo_filters[f"{column}_interval_mode"] = intmode
         return intmode
 
+    def exclusion_filter(self, columndata, name: str):
+        exclusions = st.multiselect(name, columndata)
+        self.nuevo_filters[name] = exclusions
+        return exclusions
+
 
 def main(pargs: argparse.Namespace):
     level = logging.WARNING
@@ -306,10 +311,11 @@ def main(pargs: argparse.Namespace):
                 xteintmode = dashboard.interval_mode_filter("XTE")
             with set2:
                 nicerintmode = dashboard.interval_mode_filter("NICER")
-            obsouts = st.multiselect("OBSID Exclusions", dashboard.obsids)
+            obsouts = dashboard.exclusion_filter(dashboard.obsids,
+                                                 "OBSID Exclusions")
             st.session_state.obsouts = obsouts
-            ridouts = st.multiselect("ResultID (RID) Exclusions",
-                                     table_in["RID"])
+            ridouts = dashboard.exclusion_filter(table_in["RID"],
+                                                 "ResultID (RID) Exclusions")
             st.session_state.ridouts = ridouts
             st.markdown(r"$\nu$ Error (hz)")
             table_in = dashboard.min_max_columns("NU_ERR", (0.0, 1.0))

--- a/timering/app.py
+++ b/timering/app.py
@@ -63,11 +63,6 @@ def filter_intmode(table, intmode):
     return modetable
 
 
-def filtermax(table, column, maxbound):
-    table = table.loc[table[column] <= float(maxbound)]
-    return table
-
-
 def filter_obsidout(table, obsid):
     """
     Filters out the input table of a specific OBSID
@@ -249,9 +244,15 @@ class Dashboard:
         self.logger.debug(f"Min {column} set to {minbound}")
         return table
 
+    def filtermax(self, table, column, maxbound):
+        table = table.loc[table[column] <= float(maxbound)]
+        self.nuevo_filters[f"max_{column}"] = maxbound
+        self.logger.debug(f"Max {column} set to {maxbound}")
+        return table
+
     def min_max_filters(self, column: str, minval: float,
                         maxval: float):
-        self.nuresults = filtermax(self.nuresults, column, maxval)
+        self.nuresults = self.filtermax(self.nuresults, column, maxval)
         self.nuresults = self.filtermin(self.nuresults, column, minval)
         return self.nuresults
 
@@ -275,8 +276,6 @@ class Dashboard:
             minval = st.text_input(f"Min {column}", value=default[0])
         with setb:
             maxval = st.text_input(f"Max {column}", value=default[1])
-            self.nuevo_filters[f"max_{column}"] = maxval
-            self.logger.debug(f"Max {column} set to {maxval}")
         table_in = self.min_max_filters(column, minval, maxval)
         return table_in
 


### PR DESCRIPTION
This PR add is the functionality to download the filter settings from the sidebar for the $\nu$ evolution plot.

In order to accomplish this the following changes needed to be made:

- Creation of a download settings button in the nu evolution filters dropdown on the sidebar
- Creation of a settings dumping function to dump all settings to a json file
- Refactor all filters so that the settings got added to `Dashboard.nuevo_filters` dict that could be easily dumped out
- Create way for settings files to be read in from the config.json or manually input from a user in local mode, not using a config

This PR will resolve #33 