### PR TITLE
Filtered Out Tag Addition to Result IDs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "timering"
-version = "0.0.1"
+version = "0.0.2"
 description = ""
 authors = [
     { name="Nicholas Kuechel", email="njkuechel@protonmail.com" }

--- a/timering/app.py
+++ b/timering/app.py
@@ -461,6 +461,7 @@ def main(pargs: argparse.Namespace):
     obsid = st.selectbox("OBSID", resdf_nodups["OBSID"])
     obsid_filt = resdf.loc[resdf["OBSID"] == obsid]
     obsid_filt.reset_index(drop=True, inplace=True)
+    exclude = resdf[~resdf.RID.isin(table_in.RID)].reset_index(drop=True)
     if pargs.local:
         rplots = plotting.obsid_plots(obsid_filt["TWR_FILE"][0])
     else:
@@ -468,7 +469,10 @@ def main(pargs: argparse.Namespace):
     for num, fig in enumerate(rplots["ZN2"]):
         if fig is not False:
             rid = obsid_filt["RID"][num]
-            st.markdown(f"### Result ID {rid}")
+            if rid in exclude.RID.values:
+                st.markdown(f"### Result ID {rid} (Filtered Out)")
+            else:
+                st.markdown(f"### Result ID {rid}")
             sluicing, phasecurve = st.columns(2)
             with sluicing:
                 st.pyplot(rplots["ZN2"][num])


### PR DESCRIPTION
This PR adds a tag: `(Filtered Out)` to the Result ID text on top of individual result measurements. This should make the filtering process easier by being able to identify which RIDs are being filtered out.

This PR also bumps the version to v0.0.2